### PR TITLE
DRAFT: Make scripts work with any hostname + username

### DIFF
--- a/v1/display-v1.sh
+++ b/v1/display-v1.sh
@@ -12,7 +12,7 @@ apt-get -y dist-upgrade
 apt-get install -y python3-pip
 
 # Install Waveshare e-Paper library
-pip3 install /home/hush/hushline/e-Paper/RaspberryPi_JetsonNano/python/
+pip3 install $HOME/hushline/e-Paper/RaspberryPi_JetsonNano/python/
 pip3 install qrcode[pil]
 pip3 install requests python-gnupg
 
@@ -29,7 +29,7 @@ else
 fi
 
 # Create a new script to display status on the e-ink display
-cat >/home/hush/hushline/display_status.py <<EOL
+cat >$HOME/hushline/display_status.py <<EOL
 import os
 import sys
 import time
@@ -194,10 +194,10 @@ def main():
     print("EPD initialized")
 
     # Display splash screen
-    splash_image_path = "/home/hush/hushline/splash.png"
+    splash_image_path = "$HOME/hushline/splash.png"
     display_splash_screen(epd, splash_image_path, 3)
 
-    pgp_owner_info_url = "/home/hush/hushline/public_key.asc"
+    pgp_owner_info_url = "$HOME/hushline/public_key.asc"
 
     try:
         while True:
@@ -227,7 +227,7 @@ if __name__ == '__main__':
 EOL
 
 # Create a new script to display status on the e-ink display
-cat >/home/hush/hushline/clear_display.py <<EOL
+cat >$HOME/hushline/clear_display.py <<EOL
 import sys
 from waveshare_epd import epd2in7
 from PIL import Image
@@ -262,7 +262,7 @@ Before=shutdown.target reboot.target halt.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/python3 /home/hush/hushline/clear_display.py
+ExecStart=/usr/bin/python3 $HOME/hushline/clear_display.py
 TimeoutStartSec=0
 
 [Install]
@@ -279,7 +279,7 @@ After=network.target
 
 [Service]
 User=root
-ExecStart=/usr/bin/python3 /home/hush/hushline/display_status.py
+ExecStart=/usr/bin/python3 $HOME/hushline/display_status.py
 Restart=always
 
 [Install]
@@ -292,7 +292,7 @@ sudo systemctl enable display-status.service
 sudo systemctl start display-status.service
 
 # Download splash screen image
-cd /home/hush/hushline
+cd $HOME/hushline
 wget https://raw.githubusercontent.com/scidsg/hushline-assets/main/images/splash.png
 
 echo "✅ E-ink display configuration complete. Rebooting your Raspberry Pi..."

--- a/v1/helper.sh
+++ b/v1/helper.sh
@@ -15,7 +15,7 @@ apt update && apt -y dist-upgrade && apt -y autoremove
 
 git clone https://github.com/scidsg/hushline.git
 git clone https://github.com/scidsg/blackbox.git
-chmod +x /home/hush/blackbox/v1/install-blackbox.sh
+chmod +x $HOME/blackbox/v1/install-blackbox.sh
 
 # Create a new script to display status on the e-ink display
 cat >/etc/systemd/system/blackbox-installer.service <<EOL
@@ -24,7 +24,7 @@ Description=Blackbox Installation Helper
 After=multi-user.target
 
 [Service]
-ExecStart=/home/hush/blackbox/v1/install-blackbox.sh
+ExecStart=$HOME/blackbox/v1/install-blackbox.sh
 Type=oneshot
 RemainAfterExit=yes
 

--- a/v1/install-blackbox.sh
+++ b/v1/install-blackbox.sh
@@ -40,7 +40,7 @@ sudo mv hushline.local-key.pem /etc/nginx/
 echo "Certificate and key for hushline.local have been created and moved to /etc/nginx/."
 
 # Create a virtual environment and install dependencies
-cd /home/hush/hushline
+cd $HOME/hushline
 git restore --source=HEAD --staged --worktree -- .
 git reset HEAD -- .
 git clean -fd .
@@ -75,7 +75,7 @@ else
 fi
 
 # Create a new script to capture information
-cat >/home/hush/hushline/blackbox-setup.py <<EOL
+cat >$HOME/hushline/blackbox-setup.py <<EOL
 from flask import Flask, request, render_template, redirect, url_for
 import json
 import os
@@ -114,7 +114,7 @@ def setup():
         setup_complete = True
 
         # Save the provided PGP key to a file
-        with open('/home/hush/hushline/public_key.asc', 'w') as keyfile:
+        with open('$HOME/hushline/public_key.asc', 'w') as keyfile:
             keyfile.write(pgp_public_key)
 
         return redirect(url_for('index'))
@@ -181,7 +181,7 @@ ln -sf /etc/nginx/sites-available/hushline-setup.nginx /etc/nginx/sites-enabled/
 nginx -t && systemctl restart nginx || error_exit
 
 # Create a new script to display status on the e-ink display
-cat >/home/hush/hushline/qr-setup.py <<EOL
+cat >$HOME/hushline/qr-setup.py <<EOL
 import os
 import sys
 import time
@@ -274,7 +274,7 @@ NOTIFY_SMTP_PORT=$(jq -r '.smtp_port' /tmp/setup_config.json)
 
 # Kill the Flask setup process and delete the install script
 pkill -f blackbox-setup.py
-rm /home/hush/hushline/blackbox-setup.py
+rm $HOME/hushline/blackbox-setup.py
 rm /etc/nginx/sites-available/hushline-setup.nginx
 rm /etc/nginx/sites-enabled/hushline-setup.nginx
 
@@ -535,7 +535,7 @@ HUSHLINE_PATH=""
 
 # Detect the environment (Raspberry Pi or VPS) based on some characteristic
 if [[ $(uname -n) == *"hushline"* ]]; then
-    HUSHLINE_PATH="/home/hush/hushline"
+    HUSHLINE_PATH="$HOME/hushline"
 else
     HUSHLINE_PATH="/root/hushline" # Adjusted to /root/hushline for the root user on VPS
 fi
@@ -554,7 +554,7 @@ warnings.filterwarnings("ignore", category=CryptographyDeprecationWarning)
 
 def send_notification_email(smtp_server, smtp_port, email, password):
     subject = "🎉 Blackbox Installation Complete"
-    message = "Blackbox has been successfully installed! In a moment, your device will reboot.\n\nYou can visit your tip line when you see "Blackbox is running" on your e-Paper display. If you can't immediately connect, don't panic; this is normal, as your device's information sometimes takes a few minutes to publish.\n\nYour Hush Line address is:\nhttp://$ONION_ADDRESS\n\nTo send a message, enter your address into Tor Browser. If you still need to download it, get it from https://torproject.org/download.\n\nHush Line is a free and open-source tool by Science & Design, Inc. Learn more about us at https://scidsg.org.\n\nIf you've found this resource useful, please consider making a donation at https://opencollective.com/scidsg."
+    message = "Blackbox has been successfully installed! In a moment, your device will reboot.\n\nYou can visit your tip line when you see \"Blackbox is running\" on your e-Paper display. If you can't immediately connect, don't panic; this is normal, as your device's information sometimes takes a few minutes to publish.\n\nYour Hush Line address is:\nhttp://$ONION_ADDRESS\n\nTo send a message, enter your address into Tor Browser. If you still need to download it, get it from https://torproject.org/download.\n\nHush Line is a free and open-source tool by Science & Design, Inc. Learn more about us at https://scidsg.org.\n\nIf you've found this resource useful, please consider making a donation at https://opencollective.com/scidsg."
 
     # Load the public key from its path
     key_path = os.path.expanduser('$HUSHLINE_PATH/public_key.asc')  # Use os to expand the path

--- a/v2/display-v2.sh
+++ b/v2/display-v2.sh
@@ -12,7 +12,7 @@ apt-get -y dist-upgrade
 apt-get install -y python3-pip
 
 # Install Waveshare e-Paper library
-pip3 install /home/hush/hushline/e-Paper/RaspberryPi_JetsonNano/python/
+pip3 install $HOME/hushline/e-Paper/RaspberryPi_JetsonNano/python/
 pip3 install qrcode[pil]
 pip3 install requests python-gnupg
 
@@ -29,7 +29,7 @@ else
 fi
 
 # Create a new script to display status on the e-ink display
-cat >/home/hush/hushline/display_status.py <<EOL
+cat >$HOME/hushline/display_status.py <<EOL
 import os
 import sys
 import time
@@ -195,10 +195,10 @@ def main():
     print("EPD initialized")
 
     # Display splash screen
-    splash_image_path = "/home/hush/hushline/splash.png"
+    splash_image_path = "$HOME/hushline/splash.png"
     display_splash_screen(epd, splash_image_path, 3)
 
-    pgp_owner_info_url = "/home/hush/hushline/public_key.asc"
+    pgp_owner_info_url = "$HOME/hushline/public_key.asc"
 
     try:
         while True:
@@ -228,7 +228,7 @@ if __name__ == '__main__':
 EOL
 
 # Create a new script to display status on the e-ink display
-cat >/home/hush/hushline/clear_display.py <<EOL
+cat >$HOME/hushline/clear_display.py <<EOL
 import sys
 from waveshare_epd import epd2in7_V2
 from PIL import Image
@@ -263,7 +263,7 @@ Before=shutdown.target reboot.target halt.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/python3 /home/hush/hushline/clear_display.py
+ExecStart=/usr/bin/python3 $HOME/hushline/clear_display.py
 TimeoutStartSec=0
 
 [Install]
@@ -280,7 +280,7 @@ After=network.target
 
 [Service]
 User=root
-ExecStart=/usr/bin/python3 /home/hush/hushline/display_status.py
+ExecStart=/usr/bin/python3 $HOME/hushline/display_status.py
 Restart=always
 
 [Install]
@@ -293,7 +293,7 @@ sudo systemctl enable display-status.service
 sudo systemctl start display-status.service
 
 # Download splash screen image
-cd /home/hush/hushline
+cd $HOME/hushline
 wget https://raw.githubusercontent.com/scidsg/hushline-assets/main/images/splash.png
 
 echo "✅ E-ink display configuration complete. Rebooting your Raspberry Pi..."

--- a/v2/helper.sh
+++ b/v2/helper.sh
@@ -15,7 +15,7 @@ apt update && apt -y dist-upgrade && apt -y autoremove
 
 git clone https://github.com/scidsg/hushline.git
 git clone https://github.com/scidsg/blackbox.git
-chmod +x /home/hush/blackbox/v2/install-blackbox.sh
+chmod +x $HOME/blackbox/v2/install-blackbox.sh
 
 # Create a new script to display status on the e-ink display
 cat >/etc/systemd/system/blackbox-installer.service <<EOL
@@ -24,7 +24,7 @@ Description=Blackbox Installation Helper
 After=multi-user.target
 
 [Service]
-ExecStart=/home/hush/blackbox/v2/install-blackbox.sh
+ExecStart=$HOME/blackbox/v2/install-blackbox.sh
 Type=oneshot
 RemainAfterExit=yes
 

--- a/v2/install-blackbox.sh
+++ b/v2/install-blackbox.sh
@@ -530,14 +530,8 @@ echo "y" | ufw enable
 
 echo "UFW configuration complete."
 
-HUSHLINE_PATH=""
-
-# Detect the environment (Raspberry Pi or VPS) based on some characteristic
-if [[ $(uname -n) == *"hushline"* ]]; then
-    HUSHLINE_PATH="$HOME/hushline"
-else
-    HUSHLINE_PATH="/root/hushline" # Adjusted to /root/hushline for the root user on VPS
-fi
+# Assume Raspberry Pi, since this is Blackbox
+HUSHLINE_PATH="$HOME/hushline"
 
 send_email() {
     python3 << END

--- a/v2/install-blackbox.sh
+++ b/v2/install-blackbox.sh
@@ -40,7 +40,7 @@ sudo mv hushline.local-key.pem /etc/nginx/
 echo "Certificate and key for hushline.local have been created and moved to /etc/nginx/."
 
 # Create a virtual environment and install dependencies
-cd /home/hush/hushline
+cd $HOME/hushline
 git restore --source=HEAD --staged --worktree -- .
 git reset HEAD -- .
 git clean -fd .
@@ -75,7 +75,7 @@ else
 fi
 
 # Create a new script to capture information
-cat >/home/hush/hushline/blackbox-setup.py <<EOL
+cat >$HOME/hushline/blackbox-setup.py <<EOL
 from flask import Flask, request, render_template, redirect, url_for
 import json
 import os
@@ -114,7 +114,7 @@ def setup():
         setup_complete = True
 
         # Save the provided PGP key to a file
-        with open('/home/hush/hushline/public_key.asc', 'w') as keyfile:
+        with open('$HOME/hushline/public_key.asc', 'w') as keyfile:
             keyfile.write(pgp_public_key)
 
         return redirect(url_for('index'))
@@ -181,7 +181,7 @@ ln -sf /etc/nginx/sites-available/hushline-setup.nginx /etc/nginx/sites-enabled/
 nginx -t && systemctl restart nginx || error_exit
 
 # Create a new script to display status on the e-ink display
-cat >/home/hush/hushline/display-setup-qr-beta.py <<EOL
+cat >$HOME/hushline/display-setup-qr-beta.py <<EOL
 import os
 import sys
 import time
@@ -274,7 +274,7 @@ NOTIFY_SMTP_PORT=$(jq -r '.smtp_port' /tmp/setup_config.json)
 
 # Kill the Flask setup process and delete the install script
 pkill -f blackbox-setup.py
-rm /home/hush/hushline/blackbox-setup.py
+rm $HOME/hushline/blackbox-setup.py
 rm /etc/nginx/sites-available/hushline-setup.nginx
 rm /etc/nginx/sites-enabled/hushline-setup.nginx
 
@@ -534,7 +534,7 @@ HUSHLINE_PATH=""
 
 # Detect the environment (Raspberry Pi or VPS) based on some characteristic
 if [[ $(uname -n) == *"hushline"* ]]; then
-    HUSHLINE_PATH="/home/hush/hushline"
+    HUSHLINE_PATH="$HOME/hushline"
 else
     HUSHLINE_PATH="/root/hushline" # Adjusted to /root/hushline for the root user on VPS
 fi
@@ -553,7 +553,7 @@ warnings.filterwarnings("ignore", category=CryptographyDeprecationWarning)
 
 def send_notification_email(smtp_server, smtp_port, email, password):
     subject = "🎉 Blackbox Installation Complete"
-    message = "Blackbox has been successfully installed! In a moment, your device will reboot.\n\nYou can visit your tip line when you see "Blackbox is running" on your e-Paper display. If you can't immediately connect, don't panic; this is normal, as your device's information sometimes takes a few minutes to publish.\n\nYour Hush Line address is:\nhttp://$ONION_ADDRESS\n\nTo send a message, enter your address into Tor Browser. If you still need to download it, get it from https://torproject.org/download.\n\nHush Line is a free and open-source tool by Science & Design, Inc. Learn more about us at https://scidsg.org.\n\nIf you've found this resource useful, please consider making a donation at https://opencollective.com/scidsg."
+    message = "Blackbox has been successfully installed! In a moment, your device will reboot.\n\nYou can visit your tip line when you see \"Blackbox is running\" on your e-Paper display. If you can't immediately connect, don't panic; this is normal, as your device's information sometimes takes a few minutes to publish.\n\nYour Hush Line address is:\nhttp://$ONION_ADDRESS\n\nTo send a message, enter your address into Tor Browser. If you still need to download it, get it from https://torproject.org/download.\n\nHush Line is a free and open-source tool by Science & Design, Inc. Learn more about us at https://scidsg.org.\n\nIf you've found this resource useful, please consider making a donation at https://opencollective.com/scidsg."
 
     # Load the public key from its path
     key_path = os.path.expanduser('$HUSHLINE_PATH/public_key.asc')  # Use os to expand the path


### PR DESCRIPTION
I'm trying to make the Blackbox installation scripts work with any username and hostname that the user might specify (mostly by using the `$HOME` variable), rather than requiring `hushline` and `hush` or something else specific/hard-coded. I think this will make the installation process more forgiving for users. We can, of course, still _tell_ users to enter specific hostname and username for the sake of making instructions easier to follow. 

This PR starts that work. But I haven't been able to test it because...

## Some code that makes Blackbox difficult to test

Currently, the helper script is [hard coded](https://github.com/scidsg/blackbox/blob/main/v2/helper.sh#L16-L17) to git clone the two other necessary scripts from the [https://github.com/scidsg/blackbox](https://github.com/scidsg/blackbox) repo (and presumably the `main` branch of that repo). It'd be neat if we could run test installations on other branches before merging to main. I don't know how that'd work though! Maybe the user `curl`s down the entire repo worth of scripts, and then we only use relative URLs? 