### PR TITLE
Uses raspi-config Command Line Interface to enable SPI

### DIFF
--- a/v1/helper.sh
+++ b/v1/helper.sh
@@ -7,8 +7,9 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 # Enable SPI interface
-whiptail --title "E-Ink Display Setup" --msgbox "The e-paper hat communicates with the Raspberry Pi using the SPI interface, so you need to enable it.\n\nNavigate to \"Interface Options\" > \"SPI\" and select \"Yes\" to enable the SPI interface." 12 64
-raspi-config
+# 0 for enable; 1 to disable
+# See: https://www.raspberrypi.com/documentation/computers/configuration.html#spi-nonint
+sudo raspi-config nonint do_spi 0
 
 # Update system
 apt update && apt -y dist-upgrade && apt -y autoremove

--- a/v2/helper.sh
+++ b/v2/helper.sh
@@ -7,8 +7,9 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 # Enable SPI interface
-whiptail --title "E-Ink Display Setup" --msgbox "The e-paper hat communicates with the Raspberry Pi using the SPI interface, so you need to enable it.\n\nNavigate to \"Interface Options\" > \"SPI\" and select \"Yes\" to enable the SPI interface." 12 64
-raspi-config
+# 0 for enable; 1 to disable
+# See: https://www.raspberrypi.com/documentation/computers/configuration.html#spi-nonint
+sudo raspi-config nonint do_spi 0
 
 # Update system
 apt update && apt -y dist-upgrade && apt -y autoremove


### PR DESCRIPTION
Better than #15.

Has helper scripts use the very-convenient-for-our-needs [raspi-config Command Line Interface](https://www.raspberrypi.com/documentation/computers/configuration.html#raspi-config-cli) to enable the Pi's SPI interface rather than tossing the user into the raspi-config TUI. 

Counterintuitively, [`0` is to enable and `1` is to disable](https://www.raspberrypi.com/documentation/computers/configuration.html#spi-nonint). 

I tested this by SSHing into a fresh Raspberry Pi, but **haven't tested it in a full Blackbox install**.

I'm not sure if we need `sudo`. 