### PR TITLE
fixes the SPI enable code in other scripts too

### DIFF
--- a/v1/display.sh
+++ b/v1/display.sh
@@ -21,12 +21,9 @@ pip3 install RPi.GPIO spidev
 apt-get -y autoremove
 
 # Enable SPI interface
-if ! grep -q "dtparam=spi=on" /boot/config.txt; then
-    echo "dtparam=spi=on" | sudo tee -a /boot/config.txt
-    echo "SPI interface enabled."
-else
-    echo "SPI interface is already enabled."
-fi
+# 0 for enable; 1 to disable
+# See: https://www.raspberrypi.com/documentation/computers/configuration.html#spi-nonint
+sudo raspi-config nonint do_spi 0
 
 # Create a new script to display status on the e-ink display
 cat >/home/hush/hushline/display_status.py <<EOL

--- a/v1/install.sh
+++ b/v1/install.sh
@@ -69,12 +69,9 @@ pip3 install RPi.GPIO spidev
 apt-get -y autoremove
 
 # Enable SPI interface
-if ! grep -q "dtparam=spi=on" /boot/config.txt; then
-    echo "dtparam=spi=on" | tee -a /boot/config.txt
-    echo "SPI interface enabled."
-else
-    echo "SPI interface is already enabled."
-fi
+# 0 for enable; 1 to disable
+# See: https://www.raspberrypi.com/documentation/computers/configuration.html#spi-nonint
+sudo raspi-config nonint do_spi 0
 
 # Create a new script to capture information
 cat >/home/hush/hushline/blackbox-setup.py <<EOL

--- a/v2/display.sh
+++ b/v2/display.sh
@@ -21,12 +21,9 @@ pip3 install RPi.GPIO spidev
 apt-get -y autoremove
 
 # Enable SPI interface
-if ! grep -q "dtparam=spi=on" /boot/config.txt; then
-    echo "dtparam=spi=on" | sudo tee -a /boot/config.txt
-    echo "SPI interface enabled."
-else
-    echo "SPI interface is already enabled."
-fi
+# 0 for enable; 1 to disable
+# See: https://www.raspberrypi.com/documentation/computers/configuration.html#spi-nonint
+sudo raspi-config nonint do_spi 0
 
 # Create a new script to display status on the e-ink display
 cat >/home/hush/hushline/display_status.py <<EOL

--- a/v2/install.sh
+++ b/v2/install.sh
@@ -69,12 +69,9 @@ pip3 install RPi.GPIO spidev
 apt-get -y autoremove
 
 # Enable SPI interface
-if ! grep -q "dtparam=spi=on" /boot/config.txt; then
-    echo "dtparam=spi=on" | tee -a /boot/config.txt
-    echo "SPI interface enabled."
-else
-    echo "SPI interface is already enabled."
-fi
+# 0 for enable; 1 to disable
+# See: https://www.raspberrypi.com/documentation/computers/configuration.html#spi-nonint
+sudo raspi-config nonint do_spi 0
 
 # Create a new script to capture information
 cat >/home/hush/hushline/blackbox-setup.py <<EOL


### PR DESCRIPTION
I saw the SPI enable code block in the other scripts too. I fixed them up by replacing that code block with a usage of the rasp-config cli, just like in #16. 