### PR TITLE
Proof of Concept: Add some javascript to auto-complete GMail's default smtp information

### DIFF
--- a/templates/setup.html
+++ b/templates/setup.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
-<html>
-<!DOCTYPE html>
 <html lang="en">
-<head>
+  <head>
     <meta charset="utf-8">
     <meta name="author" content="Glenn Sorrentino, Science & Design, Inc.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -18,33 +16,50 @@
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon/android-chrome-512x512.png') }}" sizes="512x512">
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon/favicon.ico') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
-</head>
-<body class="setupBody">
+  </head>
+  <body class="setupBody">
     <header>
-        <div class="wrapper">
-            <h1>⚙️ Hush Line Setup</h1>
-        </div>
+      <div class="wrapper">
+        <h1>⚙️ Hush Line Setup</h1>
+      </div>
     </header>
     <p>👋 Hush Line requires an SMTP-enabled email account - Gmail or Riseup, for example - and a PGP key that's been uploaded to a public keyserver.</p>
     <p>Not sure what to do? That's okay, <a href="https://scidsg.github.io/hushline-docs/book/intro.html" target="_blank" rel="noopener noreferrer">we'll walk you through everything you need to know right here.</a>.</p>
     <form class="setup-form" action="/setup" method="post">
-        <label for="email">Email</label>
-        <input type="email" name="email" required>
-        
-        <label for="smtp_server">SMTP Server</label>
-        <input type="text" name="smtp_server" placeholder="smtp.gmail.com" required>
+      <label for="email">Email</label>
+      <input type="email" name="email" required>
 
-        <label for="password">Password</label>
-        <input type="password" name="password" required>
+      <label for="smtp_server">SMTP Server</label>
+      <input type="text" name="smtp_server" placeholder="smtp.gmail.com" required>
 
-        <label for="smtp_port">SMTP Port</label>
-        <input type="number" name="smtp_port" placeholder="465" required>
+      <label for="password">Password</label>
+      <input type="password" name="password" required>
 
-        <label for="pgp_public_key">Public PGP Key</label>
-        <textarea name="pgp_public_key" rows="10" cols="50" required></textarea>
+      <label for="smtp_port">SMTP Port</label>
+      <input type="number" name="smtp_port" placeholder="465" required>
 
-        
-        <button type="submit">Submit</button>
+      <label for="pgp_public_key">Public PGP Key</label>
+      <textarea name="pgp_public_key" rows="10" cols="50" required></textarea>
+
+
+      <button type="submit">Submit</button>
     </form>
-</body>
+    <script>
+    // Attempt to help the user by automatically filling in gmail's default smtp info 
+    // if user enters @gmail.com into the email field
+    document.getElementsByName("email")[0].addEventListener("change", (event) => {
+      if (event.isComposing || event.keyCode === 229) {
+        return;
+      }
+      if (document.getElementsByName("email")[0].value.includes("@gmail.com") == true) {
+        // Only make changes if smtp_port and smtp_server fields are both currently empty 
+        // (we don't want to overwrite a different port or server URL that user has already entered!)
+        if (document.getElementsByName("smtp_port")[0].value == "" && document.getElementsByName("smtp_server")[0].value == "") {
+          document.getElementsByName("smtp_port")[0].value = "465";
+          document.getElementsByName("smtp_server")[0].value = "smtp.gmail.com";
+        }
+      }
+    });
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
My Javascript skills are a bit rusty (and **I doubt I put this javascript where a Flask app wants it**) but I thought, as a proof-of-concept, I'd attempt to have the Blackbox web form auto-complete the smtp info for a gmail address. 

It does this by listening for a change in the email field and, if the value includes "@gmail.com", it writes the default gmail server URL and port number into the relevant fields.

Just an idea!

Also does some light HTML formatting and removes duplicate `<html>` tag. 