### PR TITLE
adds a placeholder for PGP key textarea

### DIFF
--- a/templates/setup.html
+++ b/templates/setup.html
@@ -41,7 +41,7 @@
         <input type="number" name="smtp_port" placeholder="465" required>
 
         <label for="pgp_public_key">Public PGP Key</label>
-        <textarea name="pgp_public_key" rows="10" cols="50" required></textarea>
+        <textarea name="pgp_public_key" rows="10" cols="50" placeholder="-----BEGIN PGP PUBLIC KEY BLOCK-----" required></textarea>
 
         
         <button type="submit">Submit</button>


### PR DESCRIPTION
This will hopefully to help less knowledgeable users know to paste in the actually PGP key, rather than a URL to the key. It also has the word PUBLIC in all-caps, providing another reminder that Blackbox only needs/wants the _public_ PGP key.