### PR TITLE
Swap order of smtp server and password in setup template

### DIFF
--- a/templates/setup.html
+++ b/templates/setup.html
@@ -30,12 +30,12 @@
     <form class="setup-form" action="/setup" method="post">
         <label for="email">Email</label>
         <input type="email" name="email" required>
-        
-        <label for="smtp_server">SMTP Server</label>
-        <input type="text" name="smtp_server" placeholder="smtp.gmail.com" required>
 
         <label for="password">Password</label>
         <input type="password" name="password" required>
+        
+        <label for="smtp_server">SMTP Server</label>
+        <input type="text" name="smtp_server" placeholder="smtp.gmail.com" required>
 
         <label for="smtp_port">SMTP Port</label>
         <input type="number" name="smtp_port" placeholder="465" required>


### PR DESCRIPTION
I think people are used to seeing the password field directly after an email field. This also puts SMTP server and SMTP port fields next to each other, which is nice too.